### PR TITLE
Correct release yaml location

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -24,7 +24,7 @@ export GO111MODULE=on
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["awssqs.yaml"]="awssqs/config"
+  ["awssqs.yaml"]="config"
 )
 readonly COMPONENTS
 


### PR DESCRIPTION
Incorrectly listed as `awssqs/config` instead of the base `config` now that the dir structure has been flattened