### PR TITLE
Fix hack dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,7 @@ require (
 	k8s.io/api v0.18.12
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
-	knative.dev/eventing v0.19.1-0.20210112102830-a414aee50a2b
-	knative.dev/hack v0.0.0-20210108203236-ea9c9a0cac5c // indirect
+	knative.dev/eventing v0.20.0
 	knative.dev/pkg v0.0.0-20210107022335-51c72e24c179
 	knative.dev/test-infra v0.0.0-20210104074431-3705d2fd3e78
 )

--- a/go.sum
+++ b/go.sum
@@ -2050,8 +2050,8 @@ k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 h1:v8ud2Up6QK1lNOKFgiIVrZdMg7Mpm
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/caching v0.0.0-20190719140829-2032732871ff/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
 knative.dev/caching v0.0.0-20200116200605-67bca2c83dfa/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
-knative.dev/eventing v0.19.1-0.20210112102830-a414aee50a2b h1:xAgY7CxlRxmrWzqWtbnSry6dP/VLF/LsyMvaqTBU8wY=
-knative.dev/eventing v0.19.1-0.20210112102830-a414aee50a2b/go.mod h1:7KjOHRQTPqsH0y1NbQLnboZeWJWVTztQVd/0lFCmz7A=
+knative.dev/eventing v0.20.0 h1:CtW8JYds0gvaiCWvoeX6zHbm8Jbfwu3hieyCTNudNnk=
+knative.dev/eventing v0.20.0/go.mod h1:7KjOHRQTPqsH0y1NbQLnboZeWJWVTztQVd/0lFCmz7A=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
@@ -2059,8 +2059,6 @@ knative.dev/eventing-contrib v0.11.2 h1:xncT+JrokPG+hPUFJwue8ubPpzmziV9GUIZqYt01
 knative.dev/eventing-contrib v0.11.2/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24 h1:kIztWfvnIFV8Lhlea02K3YO2mIzcDyQNzrBLn0Oq9sA=
 knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/hack v0.0.0-20210108203236-ea9c9a0cac5c h1:B/FwfbGrZRCwujjxVzFCc1sqNcAGL5oOm0ZkSSovSU8=
-knative.dev/hack v0.0.0-20210108203236-ea9c9a0cac5c/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/pkg v0.0.0-20191101194912-56c2594e4f11/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/pkg v0.0.0-20191111150521-6d806b998379/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/pkg v0.0.0-20200207155214-fef852970f43/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=

--- a/vendor/knative.dev/hack/library.sh
+++ b/vendor/knative.dev/hack/library.sh
@@ -490,37 +490,24 @@ function start_latest_eventing_sugar_controller() {
 function run_go_tool() {
   local tool=$2
   local install_failed=0
-  local run=$1
-
-  if [[ "$(basename $1)" != "$2" ]]; then
-    echo "Assuming tool is in package $2"
-    run="${run}/$2"
-  fi
-
-  if [[ -z "$(go list -mod=readonly -f '{{.Module.Version}}' $1)" ]]; then
-    echo "Tool $1/$2 is not included in hack/tools.go, falling back to non-hermetic install (via GOPATH)."
-    if [[ -z "$(which ${tool})" ]]; then
-      local action=get
-      [[ $1 =~ ^[\./].* ]] && action=install
-      # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
-      # See discussions in https://github.com/golang/go/issues/27643.
-      if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
-        local temp_dir="$(mktemp -d)"
-        # Swallow the output as we are returning the stdout in the end.
-        pushd "${temp_dir}" > /dev/null 2>&1
-        GOFLAGS="" go ${action} "$1" || install_failed=1
-        popd > /dev/null 2>&1
-      else
-        GOFLAGS="" go ${action} "$1" || install_failed=1
-      fi
+  if [[ -z "$(which ${tool})" ]]; then
+    local action=get
+    [[ $1 =~ ^[\./].* ]] && action=install
+    # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
+    # See discussions in https://github.com/golang/go/issues/27643.
+    if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
+      local temp_dir="$(mktemp -d)"
+      # Swallow the output as we are returning the stdout in the end.
+      pushd "${temp_dir}" > /dev/null 2>&1
+      GOFLAGS="" go ${action} "$1" || install_failed=1
+      popd > /dev/null 2>&1
+    else
+      GOFLAGS="" go ${action} "$1" || install_failed=1
     fi
-    (( install_failed )) && return ${install_failed}
-    shift 2
-    ${tool} "$@"
-  else
-    shift 2
-    GOFLAGS="-mod=vendor" go run "${run}" "$@"
   fi
+  (( install_failed )) && return ${install_failed}
+  shift 2
+  ${tool} "$@"
 }
 
 # Add function call to trap

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -852,7 +852,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/eventing v0.19.1-0.20210112102830-a414aee50a2b
+# knative.dev/eventing v0.20.0
 ## explicit
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/configs
@@ -917,8 +917,7 @@ knative.dev/eventing/test/test_images/heartbeats
 knative.dev/eventing/test/test_images/performance
 knative.dev/eventing/test/test_images/print
 knative.dev/eventing/test/test_images/recordevents
-# knative.dev/hack v0.0.0-20210108203236-ea9c9a0cac5c
-## explicit
+# knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24
 knative.dev/hack
 # knative.dev/pkg v0.0.0-20210107022335-51c72e24c179
 ## explicit


### PR DESCRIPTION
This repo is indirectly depending on hack, breaking buoy and downstream dependency chain: https://github.com/knative-sandbox/eventing-autoscaler-keda/actions/runs/482227976

This fix makes this repo directly depending on hack, allowing buoy to correctly pin to the release

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>