### PR TITLE
Update Eventing API versions in samples

### DIFF
--- a/samples/awssqs-source-kube2iam.yaml
+++ b/samples/awssqs-source-kube2iam.yaml
@@ -11,6 +11,6 @@ spec:
     iam.amazonaws.com/role: AWS_IAM_ROLE
   queueUrl: QUEUE_URL
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1
     kind: Channel
     name: awssqs-test

--- a/samples/awssqs-source.yaml
+++ b/samples/awssqs-source.yaml
@@ -11,6 +11,6 @@ spec:
     key: credentials
   queueUrl: QUEUE_URL
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1
     kind: Channel
     name: awssqs-test

--- a/samples/display-resources.yaml
+++ b/samples/display-resources.yaml
@@ -1,30 +1,30 @@
 # Channel for testing events.
 
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1
 kind: Channel
 metadata:
   name: awssqs-test
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
 
 ---
 
 # Subscription from the AWS SQS Source's output Channel to the Knative Service below.
 
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1
 kind: Subscription
 metadata:
   name: awssqs-source-display
 spec:
   channel:
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1
     kind: Channel
     name: awssqs-test
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1alpha1
+      apiVersion: serving.knative.dev/v1
       kind: Service
       name: awssqs-event-display
 
@@ -32,7 +32,7 @@ spec:
 
 # This is a very simple Knative Service that prints the input event to its log.
 
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: awssqs-event-display


### PR DESCRIPTION
Fixes #121 
Closes #119

## Proposed Changes

- Update Eventing API versions in samples from `v1alpha1` to `v1`